### PR TITLE
Fix Image import for fastmcp >= 2.8.1 compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "fastmcp>=2.0.0",
+    "fastmcp>=2.8.1",
     "kroger-api>=0.2.0",
     "requests",
     "pydantic>=2.0.0",

--- a/src/kroger_mcp/tools/product_tools.py
+++ b/src/kroger_mcp/tools/product_tools.py
@@ -4,7 +4,8 @@ Product search and management tools for Kroger MCP server
 
 from typing import Dict, List, Any, Optional, Literal
 from pydantic import Field
-from fastmcp import Context, Image
+from fastmcp import Context
+from fastmcp.utilities.types import Image
 import requests
 from io import BytesIO
 


### PR DESCRIPTION
The Image class was moved from fastmcp to fastmcp.utilities.types in fastmcp v2.8.1, breaking the PyPI package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Adjusted internal import structure and updated a package version constraint.
  * No changes to runtime behavior, user-facing functionality, or configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->